### PR TITLE
Implement heart-based HUD and projectile damage handling

### DIFF
--- a/src/Players/Player1.java
+++ b/src/Players/Player1.java
@@ -16,6 +16,7 @@ import Utils.Direction;
 
 import java.awt.Color;
 
+import java.util.Collections;
 import java.util.HashMap;
 import GameObject.Rectangle;
 
@@ -51,6 +52,12 @@ public class Player1 extends MapEntity {
     protected AirGroundState airGroundState;
     protected AirGroundState previousAirGroundState;
 
+    // Health handling
+    protected int maxHealth = 5;
+    protected int currentHealth = maxHealth;
+    protected int invincibilityFrames = 0;
+    protected static final int MAX_INVINCIBILITY_FRAMES = 45;
+
     // Input handling
     protected KeyLocker keyLocker = new KeyLocker();
     protected Key JUMP_KEY = Key.W;
@@ -76,6 +83,10 @@ public class Player1 extends MapEntity {
 
         applyGravity();
 
+        if (invincibilityFrames > 0) {
+            invincibilityFrames--;
+        }
+
         // Update player state
         do {
             previousPlayerState = playerState;
@@ -99,7 +110,9 @@ public class Player1 extends MapEntity {
             float fbX = this.x + (facingDirection == Direction.RIGHT ? 24 : -7); // spawn at edge
             float fbY = this.y + -60; // roughly center vertically
             float speed = facingDirection == Direction.RIGHT ? fbSpeed : -fbSpeed;
-            fireballs.add(new Fireball(new Point(fbX, fbY), speed, fbFrames));
+            Fireball fireball = new Fireball(new Point(fbX, fbY), speed, fbFrames);
+            fireball.setMap(map);
+            fireballs.add(fireball);
         }
         if (Keyboard.isKeyUp(FIREBALL_KEY)) {
             keyLocker.unlockKey(FIREBALL_KEY);
@@ -117,6 +130,42 @@ public class Player1 extends MapEntity {
 
         // Update animation
         super.update();
+    }
+
+    public java.util.List<Fireball> getFireballs() {
+        return Collections.unmodifiableList(fireballs);
+    }
+
+    public int getCurrentHealth() {
+        return currentHealth;
+    }
+
+    public int getMaxHealth() {
+        return maxHealth;
+    }
+
+    public boolean isInvincible() {
+        return invincibilityFrames > 0;
+    }
+
+    public void takeDamage(int amount) {
+        if (amount <= 0 || isInvincible()) {
+            return;
+        }
+
+        currentHealth = Math.max(0, currentHealth - amount);
+        invincibilityFrames = MAX_INVINCIBILITY_FRAMES;
+    }
+
+    public void heal(int amount) {
+        if (amount <= 0) {
+            return;
+        }
+        currentHealth = Math.min(maxHealth, currentHealth + amount);
+    }
+
+    public boolean isDead() {
+        return currentHealth <= 0;
     }
 
     protected void applyGravity() {

--- a/src/Players/Player2.java
+++ b/src/Players/Player2.java
@@ -16,6 +16,7 @@ import Utils.Direction;
 
 import java.awt.Color;
 
+import java.util.Collections;
 import java.util.HashMap;
 import GameObject.Rectangle;
 
@@ -45,6 +46,12 @@ public class Player2 extends MapEntity {
     protected AirGroundState airGroundState;
     protected AirGroundState previousAirGroundState;
 
+    // Health handling
+    protected int maxHealth = 5;
+    protected int currentHealth = maxHealth;
+    protected int invincibilityFrames = 0;
+    protected static final int MAX_INVINCIBILITY_FRAMES = 45;
+
     // Input handling
     protected KeyLocker keyLocker = new KeyLocker();
     protected Key JUMP_KEY = Key.UP;
@@ -70,6 +77,10 @@ public class Player2 extends MapEntity {
 
         applyGravity();
 
+        if (invincibilityFrames > 0) {
+            invincibilityFrames--;
+        }
+
         // Update player state
         do {
             previousPlayerState = playerState;
@@ -93,7 +104,9 @@ public class Player2 extends MapEntity {
             float fbX = this.x + (facingDirection == Direction.RIGHT ? 24 : -7); // spawn at edge
             float fbY = this.y + -60; // roughly center vertically
             float speed = facingDirection == Direction.RIGHT ? fbSpeed : -fbSpeed;
-            fireballs.add(new Fireball(new Point(fbX, fbY), speed, fbFrames));
+            Fireball fireball = new Fireball(new Point(fbX, fbY), speed, fbFrames);
+            fireball.setMap(map);
+            fireballs.add(fireball);
         }
         if (Keyboard.isKeyUp(FIREBALL_KEY)) {
             keyLocker.unlockKey(FIREBALL_KEY);
@@ -111,6 +124,42 @@ public class Player2 extends MapEntity {
 
         // Update animation
         super.update();
+    }
+
+    public java.util.List<Fireball> getFireballs() {
+        return Collections.unmodifiableList(fireballs);
+    }
+
+    public int getCurrentHealth() {
+        return currentHealth;
+    }
+
+    public int getMaxHealth() {
+        return maxHealth;
+    }
+
+    public boolean isInvincible() {
+        return invincibilityFrames > 0;
+    }
+
+    public void takeDamage(int amount) {
+        if (amount <= 0 || isInvincible()) {
+            return;
+        }
+
+        currentHealth = Math.max(0, currentHealth - amount);
+        invincibilityFrames = MAX_INVINCIBILITY_FRAMES;
+    }
+
+    public void heal(int amount) {
+        if (amount <= 0) {
+            return;
+        }
+        currentHealth = Math.min(maxHealth, currentHealth + amount);
+    }
+
+    public boolean isDead() {
+        return currentHealth <= 0;
     }
 
     protected void applyGravity() {

--- a/src/Screens/PlayLevelScreen.java
+++ b/src/Screens/PlayLevelScreen.java
@@ -2,6 +2,7 @@ package Screens;
 
 import Engine.GraphicsHandler;
 import Engine.Screen;
+import Engine.ScreenManager;
 import Game.GameState;
 import Game.ScreenCoordinator;
 import Level.Map;
@@ -11,6 +12,9 @@ import Players.Player1;   // WASD/E controls
 import Players.Player2;   // Arrow/Enter controls
 // ...existing code...
 import SpriteFont.SpriteFont; // Importing SpriteFont for timer display
+import Utils.HealthHUD;
+import Level.MapEntityStatus;
+import Enemies.Fireball;
 
 public class PlayLevelScreen extends Screen implements PlayerListener {
     protected ScreenCoordinator screenCoordinator;
@@ -28,6 +32,10 @@ public class PlayLevelScreen extends Screen implements PlayerListener {
     protected int gameOverFrames = 0;
     protected SpriteFont timerFont;
     protected SpriteFont gameOverFont;
+    protected SpriteFont player1Label;
+    protected SpriteFont player2Label;
+    protected HealthHUD healthHUD = new HealthHUD();
+    protected String gameOverMessage = "Time's Up!";
 
     public PlayLevelScreen(ScreenCoordinator screenCoordinator) {
         this.screenCoordinator = screenCoordinator;
@@ -67,15 +75,23 @@ public class PlayLevelScreen extends Screen implements PlayerListener {
         lastTimerUpdate = System.currentTimeMillis();
         showGameOver = false;
         gameOverFrames = 0;
-    timerFont = new SpriteFont("", 0, 10, "Arial", 44, java.awt.Color.YELLOW);
-    timerFont.setOutlineColor(java.awt.Color.BLACK);
-    timerFont.setOutlineThickness(2f);
-    int gameOverTextLength = "Time's Up!".length();
-    int gameOverFontSize = 64;
-    int gameOverCenterX = 400 - (gameOverTextLength * gameOverFontSize / 4); // estimate 32px per char
-    gameOverFont = new SpriteFont("Time's Up!", gameOverCenterX, 180, "Arial", 64, java.awt.Color.RED);
-    gameOverFont.setOutlineColor(java.awt.Color.BLACK);
-    gameOverFont.setOutlineThickness(3f);
+
+        timerFont = new SpriteFont("", 0, 10, "Arial", 44, java.awt.Color.YELLOW);
+        timerFont.setOutlineColor(java.awt.Color.BLACK);
+        timerFont.setOutlineThickness(2f);
+
+        player1Label = new SpriteFont("P1", 20, 8, "Arial", 20, java.awt.Color.WHITE);
+        player1Label.setOutlineColor(java.awt.Color.BLACK);
+        player1Label.setOutlineThickness(2f);
+
+        player2Label = new SpriteFont("P2", ScreenManager.getScreenWidth() - 70, 8, "Arial", 20, java.awt.Color.WHITE);
+        player2Label.setOutlineColor(java.awt.Color.BLACK);
+        player2Label.setOutlineThickness(2f);
+
+        gameOverFont = new SpriteFont("", 0, 180, "Arial", 64, java.awt.Color.RED);
+        gameOverFont.setOutlineColor(java.awt.Color.BLACK);
+        gameOverFont.setOutlineThickness(3f);
+        updateGameOverMessage("Time's Up!");
     }
 
     // Map character name -> sprite file
@@ -92,6 +108,7 @@ public class PlayLevelScreen extends Screen implements PlayerListener {
             case RUNNING:
                 player1.update();
                 player2.update();
+                handleProjectileCollisions();
                 // Timer logic
                 long now = System.currentTimeMillis();
                 if (now - lastTimerUpdate >= 1000) {
@@ -99,8 +116,17 @@ public class PlayLevelScreen extends Screen implements PlayerListener {
                     lastTimerUpdate = now;
                 }
                 if (timerSeconds <= 0) {
-                    showGameOver = true;
-                    playLevelScreenState = PlayLevelScreenState.GAME_OVER;
+                    setGameOver("Time's Up!");
+                }
+
+                if (player1.isDead() || player2.isDead()) {
+                    if (player1.isDead() && player2.isDead()) {
+                        setGameOver("Draw!");
+                    } else if (player1.isDead()) {
+                        setGameOver("Player 2 Wins!");
+                    } else {
+                        setGameOver("Player 1 Wins!");
+                    }
                 }
                 break;
 
@@ -131,7 +157,7 @@ public class PlayLevelScreen extends Screen implements PlayerListener {
 
     @Override
     public void draw(GraphicsHandler graphicsHandler) {
-        int centerX = 400; // screen center (assuming 800px width)
+        int centerX = ScreenManager.getScreenWidth() / 2;
         switch (playLevelScreenState) {
             case RUNNING:
                 map.draw(graphicsHandler);
@@ -142,6 +168,7 @@ public class PlayLevelScreen extends Screen implements PlayerListener {
                 timerFont.setText(timerText);
                 timerFont.setX(centerX - timerText.length() * 14); // better centering for larger font
                 timerFont.draw(graphicsHandler);
+                drawHealthBars(graphicsHandler);
                 break;
             case LEVEL_COMPLETED:
                 levelClearedScreen.draw(graphicsHandler);
@@ -156,6 +183,7 @@ public class PlayLevelScreen extends Screen implements PlayerListener {
                 timerFont.setText("00:00");
                 timerFont.setX(centerX - 5 * 14); // "00:00" is 5 chars, larger font
                 timerFont.draw(graphicsHandler);
+                drawHealthBars(graphicsHandler);
                 gameOverFont.draw(graphicsHandler);
                 break;
         }
@@ -190,6 +218,65 @@ public class PlayLevelScreen extends Screen implements PlayerListener {
 
     public void goBackToCharacterSelect() {
         screenCoordinator.setGameState(GameState.CHARACTER_SELECT);
+    }
+
+    private void handleProjectileCollisions() {
+        for (Fireball fb : player1.getFireballs()) {
+            if (fb.getMapEntityStatus() == MapEntityStatus.REMOVED) {
+                continue;
+            }
+            if (!player2.isInvincible() && fb.intersects(player2)) {
+                player2.takeDamage(1);
+                fb.setMapEntityStatus(MapEntityStatus.REMOVED);
+            }
+        }
+
+        for (Fireball fb : player2.getFireballs()) {
+            if (fb.getMapEntityStatus() == MapEntityStatus.REMOVED) {
+                continue;
+            }
+            if (!player1.isInvincible() && fb.intersects(player1)) {
+                player1.takeDamage(1);
+                fb.setMapEntityStatus(MapEntityStatus.REMOVED);
+            }
+        }
+    }
+
+    private void drawHealthBars(GraphicsHandler graphicsHandler) {
+        int startY = 20;
+        int leftStartX = 60;
+        healthHUD.drawHearts(graphicsHandler, player1.getCurrentHealth(), player1.getMaxHealth(), leftStartX, startY, true);
+        player1Label.setX(20);
+        player1Label.setY(8);
+        player1Label.draw(graphicsHandler);
+
+        int heartWidth = player2.getMaxHealth() * healthHUD.getHeartSize()
+                + (player2.getMaxHealth() - 1) * healthHUD.getHeartSpacing();
+        int rightEdge = ScreenManager.getScreenWidth() - 20;
+        int rightStartX = rightEdge - healthHUD.getHeartSize();
+        healthHUD.drawHearts(graphicsHandler, player2.getCurrentHealth(), player2.getMaxHealth(), rightStartX, startY, false);
+        float labelX = Math.max(20, rightEdge - heartWidth - 60);
+        player2Label.setX(labelX);
+        player2Label.setY(8);
+        player2Label.draw(graphicsHandler);
+    }
+
+    private void setGameOver(String message) {
+        if (playLevelScreenState == PlayLevelScreenState.GAME_OVER && message.equals(gameOverMessage)) {
+            return;
+        }
+        updateGameOverMessage(message);
+        showGameOver = true;
+        playLevelScreenState = PlayLevelScreenState.GAME_OVER;
+        gameOverFrames = 0;
+    }
+
+    private void updateGameOverMessage(String message) {
+        this.gameOverMessage = message;
+        gameOverFont.setText(message);
+        int approxWidth = (int) (message.length() * (gameOverFont.getFont().getSize() * 0.55f));
+        int centerX = ScreenManager.getScreenWidth() / 2;
+        gameOverFont.setX(centerX - approxWidth / 2f);
     }
     // This enum represents the different states this screen can be in
     private enum PlayLevelScreenState {

--- a/src/Utils/HealthHUD.java
+++ b/src/Utils/HealthHUD.java
@@ -1,0 +1,84 @@
+package Utils;
+
+import Engine.GraphicsHandler;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.Stroke;
+import java.awt.geom.Path2D;
+
+/**
+ * Utility renderer for drawing heart-based health indicators on the HUD.
+ */
+public class HealthHUD {
+
+    private final int heartSize;
+    private final int heartSpacing;
+    private final Color filledColor = new Color(220, 20, 60);
+    private final Color emptyColor = new Color(100, 100, 100);
+    private final Color outlineColor = new Color(35, 35, 35);
+
+    public HealthHUD() {
+        this(26, 6);
+    }
+
+    public HealthHUD(int heartSize, int heartSpacing) {
+        this.heartSize = heartSize;
+        this.heartSpacing = heartSpacing;
+    }
+
+    public int getHeartSize() {
+        return heartSize;
+    }
+
+    public int getHeartSpacing() {
+        return heartSpacing;
+    }
+
+    public void drawHearts(GraphicsHandler graphicsHandler, int currentHearts, int maxHearts, int startX, int startY, boolean leftToRight) {
+        if (maxHearts <= 0) {
+            return;
+        }
+
+        Graphics2D g2d = graphicsHandler.getGraphics();
+        Object oldAA = g2d.getRenderingHint(RenderingHints.KEY_ANTIALIASING);
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+        for (int i = 0; i < maxHearts; i++) {
+            int offset = i * (heartSize + heartSpacing);
+            int heartX = leftToRight ? startX + offset : startX - offset;
+            drawHeart(g2d, heartX, startY, emptyColor);
+        }
+
+        for (int i = 0; i < currentHearts; i++) {
+            int offset = i * (heartSize + heartSpacing);
+            int heartX = leftToRight ? startX + offset : startX - offset;
+            drawHeart(g2d, heartX, startY, filledColor);
+        }
+
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, oldAA);
+    }
+
+    private void drawHeart(Graphics2D g2d, int x, int y, Color fillColor) {
+        Path2D.Double heart = new Path2D.Double();
+        double size = heartSize;
+        heart.moveTo(x + size / 2.0, y + size);
+        heart.curveTo(x + size * 1.1, y + size * 0.75, x + size, y + size * 0.25, x + size * 0.5, y + size * 0.35);
+        heart.curveTo(x, y + size * 0.25, x - size * 0.1, y + size * 0.75, x + size / 2.0, y + size);
+
+        Color previousColor = g2d.getColor();
+        Stroke previousStroke = g2d.getStroke();
+
+        g2d.setColor(fillColor);
+        g2d.fill(heart);
+
+        g2d.setColor(outlineColor);
+        g2d.setStroke(new BasicStroke(2f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+        g2d.draw(heart);
+
+        g2d.setColor(previousColor);
+        g2d.setStroke(previousStroke);
+    }
+}


### PR DESCRIPTION
## Summary
- track player health, invincibility frames, and expose fireball lists for both characters while ensuring projectiles inherit map context
- add a reusable HealthHUD renderer for drawing filled and empty heart icons with outlines
- integrate the heart HUD, projectile collision damage, and dynamic game-over messaging into PlayLevelScreen with player labels

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e48cb9d2348323af89ffe4bbd13e5f